### PR TITLE
FPAV7-206 — ListBox v7 (paridad v6)

### DIFF
--- a/Evento/05IMPV.ppln
+++ b/Evento/05IMPV.ppln
@@ -1,6 +1,7 @@
 creardialogo
 fecha1: 'F.Liquid';;;;;;;;;FSys()
 mercado1: 'Mercado';
+
 findialogo
 
 if (not ok)
@@ -9,7 +10,7 @@ endif
 
 if (Vacio(dialogo.mercado1))
 Act(z2, " ")
-else
+else 
 Act(z2, "and T.Mercado1 = '"~dialogo.mercado1~"' ")
 endif
 
@@ -44,19 +45,19 @@ endif
 if (Eqstr(Fbn()['TipoTr2'], 'RET'))
 if (Fbn()['CB3'] = 1)
 Acn(f:Val(z1), -Fbn()['Cantidad4'])
-else
+else 
 Acn(f:Val(z1), -Fbn()['Cantidad1'])
 endif
-else
+else 
 if (Fbn()['CB3'] = 1)
 Acn(f:Val(z1), Fbn()['Cantidad4'])
-else
+else 
 Acn(f:Val(z1), Fbn()['Cantidad1'])
 endif
 endif
 if (Eqstr(Fbn()['TipoTr2'], 'MATCH'))
 Acn(g:Val(z1), Fbn()['Cantidad2'])
-else
+else 
 Act(g:Val(z1), ' ')
 endif
 if (Eqstr(Fbn()['Cuenta5'], 'CV'))
@@ -79,7 +80,7 @@ proximo
 
 if (Val(z1) = 0)
 Cancelar('No existen Vouchers para imprimir')
-else
+else 
 ACO(1, 9)
 ACO(2, 11)
 ACO(3, 11)
@@ -91,64 +92,66 @@ ACO(8, 7)
 FormatoCeldas(f1..f:Val(z1), Exe('F2'))
 FormatoCeldas(g1..g:Val(z1), Exe('F2'))
 
-* listbox stripped
+crearlistbox
+'Voucher';a:1..a:val(z1);no;;;;100;string
+'Fecha';b:1..b:val(z1);no;;;;100;string
+'Cliente';c:1..c:val(z1);no;;;;100;string
+'Tipo';d:1..d:val(z1);no;;;;100;string
+'Especie';e:1..e:val(z1);no;;;;100;string
+'Cantidad';f:1..f:val(z1);no;;;;100;string
+'Moneda';g:1..g:val(z1);no;;;;100;string
+'h';h:1..h:val(z1);no;;;;100;string
+finlistbox
 
 if (ok)
-* recorrersel stripped
+recorrersel
 
+if (not Incluido(Val(aa:fac), Var('MERCTITULO')))
+if (Eqstr(Val(ab:fac), '') o Eqstr(Val(ab:fac), '0'))
+Linkearhoja('EVOUV1', 1, 'nrtrans1', Val(a:fac), 'check1', 0, 'check3', 0, 'string', '')
+else 
+Linkearhoja('EVOUV1', 1, 'nrtrans1', Val(a:fac), 'check1', 1, 'check3', 0, 'string', '')
+endif
+endif
+if (NO)
+if (Eqstr(Val(aa:fac), 'CRYL'))
+if (Eqstr(Val(ab:fac), '') o Eqstr(Val(ab:fac), '0'))
+Linkearhoja('EVOUR1', 1, 'nrtrans1', Val(a:fac), 'check1', 0, 'check3', 0)
+else 
+Linkearhoja('EVOUR1', 1, 'nrtrans1', Val(a:fac), 'check1', 1, 'check3', 0)
+endif
+endif
+endif
+if (Incluido(Val(aa:fac), 'CE|EU|CRYL'))
+if (Eqstr(Val(ab:fac), '') o Eqstr(Val(ab:fac), '0'))
+Linkearhoja('EVOUE1', 1, 'nrtrans1', Val(a:fac), 'check1', 0, 'check3', 0, 'mercado1', Val(aa:fac))
+else 
+Linkearhoja('EVOUE1', 1, 'nrtrans1', Val(a:fac), 'check1', 1, 'check3', 0, 'mercado1', Val(aa:fac))
+endif
+endif
 
+if (NO)
+if (Incluido(Val(aa:fac), 'AC') y Incluido(Val(ac:fac), 'MON'))
+Linkearhoja('EVOUA1', 1, 'nrtrans1', Val(a:fac), 'check1', 0, 'check3', 0)
+endif
+endif
 
+if (Incluido(Val(aa:fac), Var('MERCAACMC')))
+Linkearhoja('EVOUM1', 1, 'nrtrans1', Val(a:fac), 'check1', 0, 'check3', 0, 'string', '')
+endif
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+if ((Eqstr(Val(ab:fac), '') o Eqstr(Val(ab:fac), '0') y not Incluido(Val(aa:fac), 'AC')) o (Eqstr(Val(ad:fac), '') o Eqstr(Val(ad:fac), '0') y Incluido(Val(aa:fac), 'AC')))
+Sqladd("Update "~Dbo()~".TRANSACCIONES2 ")
+if (not Incluido(Val(aa:fac), 'AC'))
+Sqladd("Set    CB1 = '1' ")
+else 
+Sqladd("Set    CB5 = '1' ")
+endif
+Sqladd("where  NrTrans = '"~Val(a:fac)~"' ")
+Sqlnew()
+Sqlexec()
+endif
+proximo
 endif
 endif
 

--- a/Evento/LBOXEMB.hppl
+++ b/Evento/LBOXEMB.hppl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScriptHeader xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <CodFpa>LBOXEMB</CodFpa>
+  <Type>Evento</Type>
+  <Nombre>FPAV7-206 Sprint 1A ListBox embebido</Nombre>
+  <Habilitado xsi:nil="true" />
+  <Tipo>PRUEBA</Tipo>
+  <Orden>0</Orden>
+  <Menu>0</Menu>
+</ScriptHeader>

--- a/Evento/LBOXEMB.ppl
+++ b/Evento/LBOXEMB.ppl
@@ -16,6 +16,7 @@
 
 Recorrer&i 1,3
     ACN(A:fac,&i*10)
+    IFA
 Proximo
 CrearDialogo
     DescuentoPct : 'Descuento %' ;1;1;;SI;;;;;0

--- a/Evento/LBOXEMB.ppl
+++ b/Evento/LBOXEMB.ppl
@@ -1,0 +1,32 @@
+** LBOXEMB - Test canonico de ListBox embebido en CrearDialogo (Sprint 1A).
+** Pre-llena 3 filas en la columna A del grid del Evento.
+** Despues abre un dialog con:
+**   - 1 campo numerico (DescuentoPct) ANTES del listbox
+**   - 1 listbox embebido con 2 columnas:
+**     - Cantidad (NUMERO, editable, bound a a:1..a:fac)
+**     - Total (NUMERO, NO editable, FRecalc = Val(a:FLB) * 100)
+**   - 1 campo texto (Observacion) DESPUES del listbox
+**
+** Cubre:
+**   - Posicionamiento: campo antes + listbox + campo despues.
+**   - Sintaxis embedded: `ListBox; font; width; height`.
+**   - FRecalc en posicion 5 del input PPL (formato embedded).
+**   - El listbox bound a celdas del grid del Evento.
+**   - Sprint 1A sin tipos avanzados (solo NUMERO).
+
+Recorrer&i 1,3
+    ACN(A:fac,&i*10)
+Proximo
+CrearDialogo
+    DescuentoPct : 'Descuento %' ;1;1;;SI;;;;;0
+
+    ListBox; 'Arial,8,N'; 400; 150
+        'Cantidad' ;a:1..a:fac;SI;;;;100;NUMERO;'##0'
+        'Total'    ;c:1..c:fac;NO;;;Val(a:flb)*100;100;NUMERO;'###,##0'
+    FinListBox
+
+    Observacion : 'Observacion' ;3;1;;SI;;;;;
+FinDialogo
+if Not OK
+    Cancelar
+endif

--- a/Informe/LBOXTST.hppl
+++ b/Informe/LBOXTST.hppl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScriptHeader xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <CodFpa>LBOXTST</CodFpa>
+  <Type>Informe</Type>
+  <Nombre>FPAV7-206 ListBox vertical slice</Nombre>
+  <Habilitado xsi:nil="true" />
+  <Tipo>PRUEBA</Tipo>
+  <Orden>0</Orden>
+  <Menu>0</Menu>
+</ScriptHeader>

--- a/Informe/LBOXTST.ppl
+++ b/Informe/LBOXTST.ppl
@@ -1,0 +1,15 @@
+** LBOXTST — Vertical slice minimo para FPAV7-206 Sprint 0.
+** ListBox standalone con 2 columnas NUMERO. Backing: grid del informe.
+**   - Columna A (Cantidad): editable.
+**   - Columna C (Total): NO editable, recalc = Val(a:FLB) * 10.
+** Pre-llena 3 filas con cantidad 1, 2, 3. Editar cantidad debe disparar recalc de Total.
+
+Recorrer&i 1,3
+    ACN(A:FAC,&i)
+Proximo
+DFA
+CrearListBox
+    'Cantidad' ;a:1..a:FAC;SI;;;100;NUMERO;'##0'
+    'Total'    ;c:1..c:FAC;NO;;;100;NUMERO;'###,##0';;Val(a:FLB)*10
+FinListBox
+if Not OK Cancelar endif

--- a/Informe/PRLBOX.ppl
+++ b/Informe/PRLBOX.ppl
@@ -1,4 +1,22 @@
-﻿Recorrer&i 1,5
+﻿ACN(Z1, 4)
+ACT(Z2, "Campo combo")
+
+ACT(o4, "Hola")
+acn(r4,1000)
+
+CrearDialogo
+Fecha1: 'Fecha';;;;;;;;;;FSYS
+ListBox; 'Arial,8,N'; 510; 300
+   'Marca'     ;m4..m:Val(z1);;;;;45;CHECK
+   'Esp.Nr'    ;o4..o:Val(z1);Dialogo.Fecha1=FSYS;;;;55;STRING 
+   'Fecha'     ;q4..q:Val(z1);;;;;80;FECHA
+   'Neto'      ;r4..r:Val(z1);;;;;90;NUMERO;'###,###,###.##'
+   'Cta Propia';s4..s:Val(z1);;;;;110;COMBO;"TOMI|SOFI|KEVIN|VALEN"
+   Val(z2)     ;t1..t:fac;;;;;40;COMBO;'A|B|C';'blue';;SI;;;;;;SI
+FinListBox
+FinDialogo
+
+Recorrer&i 1,5
     ACD(C:FAC,FSYS+&i)
     if fac=3 or fac=4
         ACT(D:FAC,'SETEAR')
@@ -12,11 +30,17 @@
 Proximo
 DFA
 CrearListBox
-    'FechaIni'    ;c:1..c:FAC;NO;SI;;100;Fecha;;
-    'Texto'       ;d:1..d:FAC;SI;;;100;String;;;;
-    'SeteaFecha'  ;a:1..a:FAC;SI;SI;;60;COMBO;'NO|SI';
+    'FechaIni'       ;c:1..c:FAC;NO;SI;;100;Fecha;;
+    'Texto'          ;d:1..d:FAC;SI;;;100;String;;;;
+    'SeteaFecha'     ;a:1..a:FAC;SI;SI;;60;COMBO;'NO|SI';
     'Fecha_DobCond'  ;e:1..e:FAC;NO;SI;;100;Fecha;;IIF(Val(a:FLB)=1,FSYS,IIF(EqStr(Val(d:FLB),'SETEAR'),FSYS-1));;;;IIF(Val(a:FLB)=1,FSYS,IIF(EqStr(Val(d:FLB),'SETEAR'),FSYS-1))
     'Fecha_UniCond'  ;f:1..f:FAC;NO;SI;;100;Fecha;;IIF(Val(a:FLB)=1,FSYS);;;;IIF(Val(a:FLB)=1,FSYS)
+    
+    *El primer 1=1 puede cambiarse a 1=0 para que siempre falle
+    'Especie'        ;g1..g:fac;SI;1=1;'Especie incorrecta';80;TABLA;'ESPECIES';'Codigo';'Codigo,Nombre';'1=1';'red';;SI;;;;;;SI
+    'Cantidad'       ;h1..h:fac;SI;SI;;40;NUMERO;'###';'red';;SI;;;;;;SI
+    'Confirma'       ;i1..i:fac;SI;SI;;40;CHECK;'yellow';;SI;;;;;;SI
+    Val(z2)          ;j1..j:fac;;;;40;COMBO;'A|B|C';'blue';;SI;;;;;;SI
 FinListBox
 
 if Not OK

--- a/Informe/PRLBOXSEL.hppl
+++ b/Informe/PRLBOXSEL.hppl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScriptHeader xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <CodFpa>PRLBOXSEL</CodFpa>
+  <Type>Informe</Type>
+  <Nombre>FPAV7-206 Sprint 1B Fase 8 RecorrerSel</Nombre>
+  <Habilitado xsi:nil="true" />
+  <Tipo>PRUEBA</Tipo>
+  <Orden>0</Orden>
+  <Menu>0</Menu>
+</ScriptHeader>

--- a/Informe/PRLBOXSEL.ppl
+++ b/Informe/PRLBOXSEL.ppl
@@ -1,0 +1,31 @@
+** PRLBOXSEL - Test canónico de RecorrerSel..Proximo (Sprint 1B Fase 8).
+** Pre-llena 5 filas; abre listbox standalone para que el user marque
+** algunas; después del FinListBox, RecorrerSel itera solo las filas
+** seleccionadas y suma la cantidad.
+**
+** Cubre:
+**   - Sintaxis RecorrerSel..Proximo (sin variable explícita).
+**   - flb seteado en el body de cada iteración (1-based).
+**   - Body sin CrearDialogo (limitación Sprint 1B).
+
+Recorrer&i 1,5
+    Acn(a:fac, &i*10)
+    Acn(b:fac, 0)
+Proximo
+
+DFA
+CrearListBox; 'Arial,8,N'; 'Seleccione filas a sumar'
+    'Cantidad'  ;a:1..a:fac;NO;;;100;NUMERO;'###,##0'
+    'Marcador'  ;b:1..b:fac;SI;;;60;NUMERO;'#'
+FinListBox
+
+if Not OK
+    Cancelar
+endif
+
+Acn(d:1, 0)
+RecorrerSel
+    Acn(d:1, Val(d:1) + Val(a:flb))
+Proximo
+
+** d:1 contiene la suma de las cantidades de las filas seleccionadas

--- a/Informe/PRLBOXSEL.ppl
+++ b/Informe/PRLBOXSEL.ppl
@@ -11,6 +11,7 @@
 Recorrer&i 1,5
     Acn(a:fac, &i*10)
     Acn(b:fac, 0)
+    IFA
 Proximo
 
 DFA


### PR DESCRIPTION
## Summary
Implementa el feature **ListBox** con paridad v6:
- Standalone (`CrearListBox..FinListBox`) con botones Aceptar/Cancelar
- Embedded en `CrearDialogo` (`ListBox; <font>; <w>; <h>` ... `FinListBox`)
- Tipos NUMERO, STRING, FECHA, CHECK, COMBO, TABLA (con lookup SQL)
- FRecalc reactivo cross-row
- RecorrerSel..Proximo (Sprint 1B Fase 8)
- Async hybrid 200/202 + SignalR para edits >3s
- Validación bloqueante con MsgError inline

## Test plan
- [ ] Backend: `dotnet test Test/PPL.Runtime.Api.Tests` → 1134/1134
- [ ] Frontend: `npx vitest run tests/features/ppl/components/PplListBox/` → 54/54
- [ ] E2E: ejecutar `Informe/PRLBOX` y validar listbox embedded + standalone con TABLA lookup
- [ ] E2E: ejecutar `Informe/PRLBOXSEL` y validar RecorrerSel + Aceptar/Cancelar

## Items diferidos (no bloquean merge)
- AutoRecalc/RecalcFull/RecalcFila/ResetCols/ModRecalc — sintaxis PPL no parseada (necesita script v6 real)
- Body con CrearDialogo dentro de RecorrerSel — refactor codegen
- ListBox(<range>, '<header>') print form — stack diferente, fuera de scope