### PR TITLE
FPAV7-209

### DIFF
--- a/Evento/MAILTS.hppl
+++ b/Evento/MAILTS.hppl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScriptHeader xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <CodFpa>MAILTS</CodFpa>
+  <Type>Evento</Type>
+  <Nombre>Test SendMail (FPAV7-209)</Nombre>
+  <Habilitado xsi:nil="true" />
+  <Tipo>GRAL</Tipo>
+  <Orden>0</Orden>
+  <Menu>0</Menu>
+</ScriptHeader>

--- a/Evento/MAILTS.ppl
+++ b/Evento/MAILTS.ppl
@@ -1,0 +1,27 @@
+** FPAV7-209 - Test E2E del subsistema SendMail.
+** Standalone: no depende de tabla VARIABLES, USUARIOS ni archivos en disco.
+** Apunta al SMTP configurado en appsettings.json (Mail.Host).
+**
+** Por default solo ejecuta el Caso 1. Para probar otros casos,
+** comentar el Caso 1 con * y descomentar el caso a probar.
+
+** ===== Caso 1: mail basico texto plano =====
+SendMail('test@local.dev', 'Test SendMail v7 - basico', 'Mail de prueba en texto plano.')
+
+** ===== Caso 2: mail HTML (debe generar multipart/alternative) =====
+*SendMail('test@local.dev', 'Test SendMail v7 - HTML', '<html><body><h1>Hola</h1><p>Mail <b>HTML</b> de prueba.</p></body></html>')
+
+** ===== Caso 3: destinatario sin dominio (auto-completion con DefaultDomain) =====
+*SendMail('tomi', 'Test SendMail v7 - autocompletion', 'El destinatario debe llegar como tomi@local.dev')
+
+** ===== Caso 4: con host override (apunta a otro SMTP en runtime) =====
+*SendMail('test@local.dev', 'Test SendMail v7 - host override', 'Con host explicito.', SI, 'localhost')
+
+** ===== Caso 5: con ReplyTo =====
+*SendMail('test@local.dev', 'Test SendMail v7 - ReplyTo', 'Con ReplyTo configurado.', SI, 'localhost', 'reply@local.dev')
+
+If ok
+   MessageBox('Resultado: OK')
+Else
+   MessageBox('Resultado: FALLO')
+EndIf


### PR DESCRIPTION
Script de evento standalone (no depende de tabla VARIABLES, USUARIOS ni archivos en disco) para validar el feature SendMail de v7 contra un servidor SMTP de prueba (smtp4dev local en localhost:2525).

Cubre 5 casos comentables/descomentables:
- Caso 1: texto plano básico (default activo)
- Caso 2: HTML con multipart/alternative auto-generado
- Caso 3: destinatario sin dominio (auto-completion con DefaultDomain)
- Caso 4: host override en runtime
- Caso 5: ReplyTo

El MessageBox final reporta el flag ok del envío (OK / FALLO).