### PR TITLE
FPAV7-395 222 QA

### DIFF
--- a/Funcion/GENVOUDBO.ppl
+++ b/Funcion/GENVOUDBO.ppl
@@ -78,9 +78,6 @@
           SCN(o:&i, FBN('Cantidad')*Val(dc:&i))
        proximo
                   
-       MessageBox('celda o ' ~Val(o:&i) )
-       MessageBox('celda k ' ~Val(k:&i) )
-       MessageBox('celda d ' ~Val(dc:&i))
 Message('Cliente: '~Val(a:&i)~' - Especie: '~Val(j:&i))
 
 *messagebox('Select a pasar '~Val(o:&i)~' - Movs iniciales '~Val(k:&i)~' *')


### PR DESCRIPTION
chore(01LIQU): quitar MessageBox de debug de GENVOUDBO

Los 3 MessageBox('celda o/k/d') eran diagnostico agregado para investigar el "NO SE LIQUIDA" (que resulto ser deploy viejo, ya resuelto en develop) — no deben quedar en produccion.